### PR TITLE
hide tutorial button unless logged in

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -26,11 +26,12 @@
           </div>
         <% end %>
       </div>
-      <div class="col-sm-4">
-        <h4>How to Help</h4>
-        <%= link_to "Create a Tutorial", new_tutorial_path, class: "btn btn-danger" %>
-      </div>
-      </div>
+      <% if user_signed_in? %>
+        <div class="col-sm-4">
+          <h4>How to Help</h4>
+          <%= link_to "Create a Tutorial", new_tutorial_path, class: "btn btn-danger" %>
+        </div>
+      <% end %>
     </div>
     <div class="row"></div>
       <div class="col-sm-12 text-center">


### PR DESCRIPTION
unless the user is signed in, i think we should hide the create a tutorial button. the button is bright red, so this will keep un logged in users from trying to create a tutorial. there's also no reason for them to see it.